### PR TITLE
Fix signature cache after rebase

### DIFF
--- a/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
+++ b/rskj-core/src/main/java/co/rsk/core/bc/TransactionPoolImpl.java
@@ -255,7 +255,7 @@ public class TransactionPoolImpl implements TransactionPool {
         }
 
         pendingTransactions.addTransaction(tx);
-
+        signatureCache.storeSender(tx);
         return TransactionPoolAddResult.ok();
     }
 
@@ -281,8 +281,6 @@ public class TransactionPoolImpl implements TransactionPool {
         added.addAll(this.addSuccesors(tx));
 
         this.emitEvents(added);
-
-        signatureCache.storeSender(tx);
 
         return result;
     }

--- a/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
+++ b/rskj-core/src/test/java/co/rsk/core/bc/TransactionPoolImplTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.*;
  * Created by ajlopez on 08/08/2016.
  */
 public class TransactionPoolImplTest {
-    private static final int MAX_CACHE_SIZE = 6001;
+    private static final int MAX_CACHE_SIZE = 6000;
     private Blockchain blockChain;
     private TransactionPoolImpl transactionPool;
     private Repository repository;
@@ -766,14 +766,14 @@ public class TransactionPoolImplTest {
     public void firstTxIsRemovedWhenTheCacheLimitSizeIsExceeded() {
         Coin balance = Coin.valueOf(1000000);
         createTestAccounts(6005, balance);
-        Transaction tx = createSampleTransaction(1, 2, 1, 1);
+        Transaction tx = createSampleTransaction(1, 2, 1, 0);
         transactionPool.addTransaction(tx);
 
         for (int i = 0; i < MAX_CACHE_SIZE; i++) {
             if (i == MAX_CACHE_SIZE - 1) {
                 Assert.assertTrue(signatureCache.containsTx(tx));
             }
-            Transaction sampleTransaction = createSampleTransaction(i, 2, 1, 0);
+            Transaction sampleTransaction = createSampleTransaction(i+2, 2, 1, 1);
             transactionPool.addTransaction(sampleTransaction);
             Assert.assertTrue(TransactionPoolAddResult.ok().transactionWasAdded());
 
@@ -807,6 +807,8 @@ public class TransactionPoolImplTest {
 
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+        Assert.assertTrue(signatureCache.containsTx(tx1));
+        Assert.assertTrue(signatureCache.containsTx(tx2));
     }
 
     @Test
@@ -826,5 +828,7 @@ public class TransactionPoolImplTest {
 
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx2.getHash())));
         Assert.assertTrue(transactionPool.getPendingTransactions().stream().anyMatch(tx -> tx.getHash().equals(tx1.getHash())));
+        Assert.assertTrue(signatureCache.containsTx(tx1));
+        Assert.assertTrue(signatureCache.containsTx(tx2));
     }
 }


### PR DESCRIPTION
addInternalTx has two paths to becoming a tx as successful until now just one was considered for storing tx in the sign cache, now both are taking account. 